### PR TITLE
protobuf imports switched to github.com

### DIFF
--- a/OSMPBF/fileformat.pb.go
+++ b/OSMPBF/fileformat.pb.go
@@ -15,7 +15,7 @@ It has these top-level messages:
 */
 package OSMPBF
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/OSMPBF/osmformat.pb.go
+++ b/OSMPBF/osmformat.pb.go
@@ -4,7 +4,7 @@
 
 package OSMPBF
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/decode.go
+++ b/decode.go
@@ -1,19 +1,20 @@
 // Package osmpbf decodes OpenStreetMap (OSM) PBF files.
 // Use this package by creating a NewDecoder and passing it a PBF file.
-// Use Start to start decoding process. 
+// Use Start to start decoding process.
 // Use Decode to return Node, Way and Relation structs.
 package osmpbf
 
 import (
 	"bytes"
-	"code.google.com/p/goprotobuf/proto"
 	"compress/zlib"
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/qedus/osmpbf/OSMPBF"
 	"io"
 	"time"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/qedus/osmpbf/OSMPBF"
 )
 
 const (

--- a/decode_data.go
+++ b/decode_data.go
@@ -1,9 +1,10 @@
 package osmpbf
 
 import (
-	"code.google.com/p/goprotobuf/proto"
-	"github.com/qedus/osmpbf/OSMPBF"
 	"time"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/qedus/osmpbf/OSMPBF"
 )
 
 // Decoder for Blob with OSMData (PrimitiveBlock)


### PR DESCRIPTION
`go get` fails on this repository because protobuf has moved.

code.google.com/p/protobuf now redirects to github.com/google/protobuf

Updated the imports to the new URL.
