### PR TITLE
Made OSM header accessible

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -331,7 +331,9 @@ func getData(blob *OSMPBF.Blob) ([]byte, error) {
 func (dec *Decoder) readOSMHeader() error {
 	var err error
 	dec.headerOnce.Do(func() {
-		blobHeader, blob, err := dec.readFileBlock()
+		var blobHeader *OSMPBF.BlobHeader
+		var blob *OSMPBF.Blob
+		blobHeader, blob, err = dec.readFileBlock()
 		if err == nil {
 			if blobHeader.GetType() == "OSMHeader" {
 				err = dec.decodeOSMHeader(blob)

--- a/decode.go
+++ b/decode.go
@@ -35,21 +35,21 @@ var (
 )
 
 type Bbox struct {
-	Left float64
-	Right float64
-	Top float64
+	Left   float64
+	Right  float64
+	Top    float64
 	Bottom float64
 }
 
 type Header struct {
-	Bbox *Bbox
-	RequiredFeatures []string
-	OptionalFeatures []string
-	WritingProgram string
-	Source string
-	OsmosisReplicationTimestamp time.Time
+	Bbox                             *Bbox
+	RequiredFeatures                 []string
+	OptionalFeatures                 []string
+	WritingProgram                   string
+	Source                           string
+	OsmosisReplicationTimestamp      time.Time
 	OsmosisReplicationSequenceNumber int64
-	OsmosisReplicationBaseUrl string
+	OsmosisReplicationBaseUrl        string
 }
 
 type Info struct {
@@ -353,7 +353,7 @@ func getData(blob *OSMPBF.Blob) ([]byte, error) {
 }
 
 func (dec *Decoder) readOSMHeader() (*Header, error) {
-	blobHeader, blob, err :=  dec.readFileBlock()
+	blobHeader, blob, err := dec.readFileBlock()
 	if err == nil {
 		if blobHeader.GetType() == "OSMHeader" {
 			return decodeOSMHeader(blob)
@@ -388,9 +388,9 @@ func decodeOSMHeader(blob *OSMPBF.Blob) (*Header, error) {
 	header := &Header{
 		RequiredFeatures: headerBlock.GetRequiredFeatures(),
 		OptionalFeatures: headerBlock.GetOptionalFeatures(),
-		WritingProgram: headerBlock.GetWritingprogram(),
-		Source: headerBlock.GetSource(),
-		OsmosisReplicationBaseUrl: headerBlock.GetOsmosisReplicationBaseUrl(),
+		WritingProgram:   headerBlock.GetWritingprogram(),
+		Source:           headerBlock.GetSource(),
+		OsmosisReplicationBaseUrl:        headerBlock.GetOsmosisReplicationBaseUrl(),
 		OsmosisReplicationSequenceNumber: headerBlock.GetOsmosisReplicationSequenceNumber(),
 	}
 
@@ -402,10 +402,10 @@ func decodeOSMHeader(blob *OSMPBF.Blob) (*Header, error) {
 	if headerBlock.Bbox != nil {
 		// Units are always in nanodegree and do not obey granularity rules. See osmformat.proto
 		header.Bbox = &Bbox{
-			Left: 1e-9 * float64(*headerBlock.Bbox.Left),
-			Right: 1e-9 * float64(*headerBlock.Bbox.Right),
+			Left:   1e-9 * float64(*headerBlock.Bbox.Left),
+			Right:  1e-9 * float64(*headerBlock.Bbox.Right),
 			Bottom: 1e-9 * float64(*headerBlock.Bbox.Bottom),
-			Top: 1e-9 * float64(*headerBlock.Bbox.Top),
+			Top:    1e-9 * float64(*headerBlock.Bbox.Top),
 		}
 	}
 

--- a/decode.go
+++ b/decode.go
@@ -34,7 +34,7 @@ var (
 	}
 )
 
-type Bbox struct {
+type BoundingBox struct {
 	Left   float64
 	Right  float64
 	Top    float64
@@ -42,7 +42,7 @@ type Bbox struct {
 }
 
 type Header struct {
-	BoundingBox                      *Bbox
+	BoundingBox                      *BoundingBox
 	RequiredFeatures                 []string
 	OptionalFeatures                 []string
 	WritingProgram                   string
@@ -380,7 +380,7 @@ func (dec *Decoder) decodeOSMHeader(blob *OSMPBF.Blob) error {
 	// read bounding box if it exists
 	if headerBlock.Bbox != nil {
 		// Units are always in nanodegree and do not obey granularity rules. See osmformat.proto
-		header.BoundingBox = &Bbox{
+		header.BoundingBox = &BoundingBox{
 			Left:   1e-9 * float64(*headerBlock.Bbox.Left),
 			Right:  1e-9 * float64(*headerBlock.Bbox.Right),
 			Bottom: 1e-9 * float64(*headerBlock.Bbox.Bottom),

--- a/decode_test.go
+++ b/decode_test.go
@@ -57,6 +57,21 @@ var (
 	ewc uint64 = 459055
 	erc uint64 = 12833
 
+	eh = &Header{
+		Bbox: &Bbox{
+			Right: 0.335437,
+			Left: -0.511482,
+			Bottom: 51.28554,
+			Top: 51.69344,
+		},
+		OsmosisReplicationTimestamp: time.Date(2014, 3, 24, 22, 55, 2, 0, time.FixedZone("test", 3600)),
+		RequiredFeatures: []string {
+			"OsmSchema-V0.6",
+			"DenseNodes",
+		},
+		WritingProgram: `Osmium (http:\/\/wiki.openstreetmap.org\/wiki\/Osmium)`,
+	}
+
 	en = &Node{
 		ID:  18088578,
 		Lat: 51.5442632,
@@ -152,6 +167,34 @@ func downloadTestOSMFile(t *testing.T) {
 	}
 }
 
+func checkHeader(a *Header) bool {
+	if a == nil || a.Bbox == nil || a.RequiredFeatures == nil || a.WritingProgram == nil {
+		return false
+	}
+
+	// check bbox
+	if a.Bbox.Right != eh.Bbox.Right || a.Bbox.Left != eh.Bbox.Left || a.Bbox.Top != eh.Bbox.Top || a.Bbox.Bottom != eh.Bbox.Bottom {
+		return false
+	}
+
+	// check timestamp
+	if !a.OsmosisReplicationTimestamp.Equal(eh.OsmosisReplicationTimestamp) {
+		return false
+	}
+
+	// check writing program
+	if a.WritingProgram != eh.WritingProgram {
+		return false
+	}
+
+	// check features
+	if len(a.RequiredFeatures) != len(eh.RequiredFeatures) || a.RequiredFeatures[0] != eh.RequiredFeatures[0] || a.RequiredFeatures[1] != eh.RequiredFeatures[1] {
+		return false
+	}
+
+	return true
+}
+
 func TestDecode(t *testing.T) {
 	downloadTestOSMFile(t)
 
@@ -163,6 +206,15 @@ func TestDecode(t *testing.T) {
 
 	d := NewDecoder(f)
 	d.SetBufferSize(1)
+
+	header, err := d.Header()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checkHeader(header) {
+		t.Errorf("\nExpected: %#v\nActual:   %#v", eh, header)
+	}
+
 	err = d.Start(runtime.GOMAXPROCS(-1))
 	if err != nil {
 		t.Fatal(err)
@@ -246,6 +298,14 @@ func TestDecodeConcurrent(t *testing.T) {
 	err = d.Start(runtime.GOMAXPROCS(-1))
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	header, err := d.Header()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checkHeader(header) {
+		t.Errorf("\nExpected: %#v\nActual:   %#v", eh, header)
 	}
 
 	var n *Node

--- a/decode_test.go
+++ b/decode_test.go
@@ -168,7 +168,7 @@ func downloadTestOSMFile(t *testing.T) {
 }
 
 func checkHeader(a *Header) bool {
-	if a == nil || a.Bbox == nil || a.RequiredFeatures == nil || a.WritingProgram == nil {
+	if a == nil || a.Bbox == nil || a.RequiredFeatures == nil {
 		return false
 	}
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -59,13 +59,13 @@ var (
 
 	eh = &Header{
 		Bbox: &Bbox{
-			Right: 0.335437,
-			Left: -0.511482,
+			Right:  0.335437,
+			Left:   -0.511482,
 			Bottom: 51.28554,
-			Top: 51.69344,
+			Top:    51.69344,
 		},
 		OsmosisReplicationTimestamp: time.Date(2014, 3, 24, 22, 55, 2, 0, time.FixedZone("test", 3600)),
-		RequiredFeatures: []string {
+		RequiredFeatures: []string{
 			"OsmSchema-V0.6",
 			"DenseNodes",
 		},

--- a/decode_test.go
+++ b/decode_test.go
@@ -58,7 +58,7 @@ var (
 	erc uint64 = 12833
 
 	eh = &Header{
-		BoundingBox: &Bbox{
+		BoundingBox: &BoundingBox{
 			Right:  0.335437,
 			Left:   -0.511482,
 			Bottom: 51.28554,

--- a/decode_test.go
+++ b/decode_test.go
@@ -58,7 +58,7 @@ var (
 	erc uint64 = 12833
 
 	eh = &Header{
-		Bbox: &Bbox{
+		BoundingBox: &Bbox{
 			Right:  0.335437,
 			Left:   -0.511482,
 			Bottom: 51.28554,
@@ -168,12 +168,12 @@ func downloadTestOSMFile(t *testing.T) {
 }
 
 func checkHeader(a *Header) bool {
-	if a == nil || a.Bbox == nil || a.RequiredFeatures == nil {
+	if a == nil || a.BoundingBox == nil || a.RequiredFeatures == nil {
 		return false
 	}
 
 	// check bbox
-	if a.Bbox.Right != eh.Bbox.Right || a.Bbox.Left != eh.Bbox.Left || a.Bbox.Top != eh.Bbox.Top || a.Bbox.Bottom != eh.Bbox.Bottom {
+	if a.BoundingBox.Right != eh.BoundingBox.Right || a.BoundingBox.Left != eh.BoundingBox.Left || a.BoundingBox.Top != eh.BoundingBox.Top || a.BoundingBox.Bottom != eh.BoundingBox.Bottom {
 		return false
 	}
 


### PR DESCRIPTION
As far as I could see there was no way so far to get hand on the OSM header information. It was only being decoded to check if the parser is capable of processing the file. 
I added the possibility to get the header via the decoder which reads it from the file and stores it in the struct. The header will only be read one time from the file. 