### PR TITLE
Use benchstat instead of benchcmp.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ go:
 
 install:
   - go get -v github.com/qedus/osmpbf
-  - go get -u golang.org/x/tools/cmd/benchcmp
 
 script:
+  - make init
   - make race
   - make cover
   - make bench

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 sudo: false
 go:
-  - 1.5.x
   - 1.6.x
   - 1.7.x
   - 1.8.x

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ export GORACE := halt_on_error=1
 
 all: cover
 
+init:
+	go get -u golang.org/x/perf/cmd/benchstat
+
 race:
 	go install -v -race
 	go test -v -race
@@ -11,6 +14,6 @@ cover:
 	go test -v -coverprofile=profile.cov
 
 bench:
-	env OSMPBF_BENCHMARK_BUFFER=1048576  go test -v -run=NONE -bench=. -benchmem -benchtime=10s | tee 01.txt
-	env OSMPBF_BENCHMARK_BUFFER=33554432 go test -v -run=NONE -bench=. -benchmem -benchtime=10s | tee 32.txt
-	benchcmp 01.txt 32.txt
+	env OSMPBF_BENCHMARK_BUFFER=1048576  go test -v -run=NONE -bench=. -benchmem -benchtime=10s -count=5 | tee 01.txt
+	env OSMPBF_BENCHMARK_BUFFER=33554432 go test -v -run=NONE -bench=. -benchmem -benchtime=10s -count=5 | tee 32.txt
+	benchstat 01.txt 32.txt


### PR DESCRIPTION
A side-effect of me benchmarking various projects I contributed to with the upcoming Go 1.10.

```
$ benchstat go1.9.2_01.txt goDevel_01.txt

name                old time/op    new time/op    delta
Decode-4               2.27s ± 3%     2.16s ± 2%  -5.10%  (p=0.008 n=5+5)
DecodeConcurrent-4     2.30s ± 1%     2.08s ± 3%  -9.80%  (p=0.008 n=5+5)

name                old alloc/op   new alloc/op   delta
Decode-4              1.89GB ± 0%    1.88GB ± 0%  -0.11%  (p=0.008 n=5+5)
DecodeConcurrent-4    1.89GB ± 0%    1.88GB ± 0%  -0.11%  (p=0.008 n=5+5)

name                old allocs/op  new allocs/op  delta
Decode-4               13.0M ± 0%     13.0M ± 0%  +0.00%  (p=0.008 n=5+5)
DecodeConcurrent-4     13.0M ± 0%     13.0M ± 0%  +0.00%  (p=0.008 n=5+5)
```

```
$ benchstat go1.9.2_32.txt goDevel_32.txt

name                old time/op    new time/op    delta
Decode-4               1.53s ± 2%     1.44s ± 1%  -5.94%  (p=0.008 n=5+5)
DecodeConcurrent-4     1.61s ± 3%     1.48s ± 1%  -7.72%  (p=0.008 n=5+5)

name                old alloc/op   new alloc/op   delta
Decode-4              1.92GB ± 0%    1.92GB ± 0%  -0.10%  (p=0.008 n=5+5)
DecodeConcurrent-4    1.92GB ± 0%    1.92GB ± 0%  -0.10%  (p=0.008 n=5+5)

name                old allocs/op  new allocs/op  delta
Decode-4               13.0M ± 0%     13.0M ± 0%  +0.00%  (p=0.008 n=5+5)
DecodeConcurrent-4     13.0M ± 0%     13.0M ± 0%  +0.00%  (p=0.008 n=5+5)
```